### PR TITLE
Media section added above FAQ, added link under community.

### DIFF
--- a/html/css/custom.css
+++ b/html/css/custom.css
@@ -116,3 +116,45 @@ p.question {
   justify-content: center;
   margin-bottom: 1.5em;
 }
+
+
+.media a {
+  display:block;
+  color:#f08b16;
+  margin-bottom:0;
+  line-height:1.2;
+}
+
+.media .panel {
+  background:#fff;
+  border:1px solid #eee;
+  border-width:1px 1px 3px;
+  padding:2em;
+  height:18em;
+  overflow:auto;
+}
+
+.media .panel h4 {
+  font-weight:300;
+  margin-bottom:0;
+}
+
+.media .panel li {
+  padding:1em 0;
+  border-bottom:1px solid #eee;
+}
+
+.media .panel li:last-child {
+  border-bottom:0;
+}
+
+.media .panel.press-releases a{
+  color:#4a90e2;
+}
+
+.media .meta {
+  font-size:0.7em;
+  color:#9d9d9d;
+}
+
+

--- a/html/index.html
+++ b/html/index.html
@@ -98,6 +98,11 @@ gtag('config', 'UA-17656782-2');
                                                                     Exchanges
                                                                 </a>
                                                             </li>
+                                                            <li>
+                                                                <a href="#media" class="inner-link">
+                                                                    Media
+                                                                </a>
+                                                            </li>
                                                         </ul>
                                                     </div>
                                                 </div>
@@ -361,7 +366,7 @@ gtag('config', 'UA-17656782-2');
                 </div>
             </section>
             <a id="exchanges"></a>
-            <section class="space--xxs text-center gray">
+            <section class="space--xxs text-center gray border-bottom">
                 <div class="container exchanges">
                     <div class="row">
                         <div class="col-xs-12">
@@ -452,6 +457,126 @@ gtag('config', 'UA-17656782-2');
                         </div>
                         <div class="col-sm-4 col-md-3 vertical-align">
                             <a href="https://www.bitcoin.de/" target="_blank"><img alt="Bitcoin.de" src="img/exchanges/bitcoinde.png"></a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <a id="media"></a>
+            <section class="space--xxs text-center gray">
+                <div class="container media">
+                    <div class="row text-center">
+                        <div class="col-xs-12">
+                            <h3>Media</h3>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-xs-12 col-sm-6 col-md-6">
+                            <div class="panel in-the-news">
+                            <h4>In The News</h4>
+                                <ul>
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#">Hashrate growing on Bitcoin Cash.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span> | <span class="source">Source: XYZ Co.</span>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+
+                        </div>
+
+                        <div class="col-xs-12 col-sm-6 col-md-6">
+                            <div class="panel press-releases">
+                            <h4>Press Releases</h4>
+                                <ul>
+                                    <li>
+                                        <a href="#"><i class="fa fa-paperclip"></i> New developments in Bitcoin Cash</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span></span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#"><i class="fa fa-paperclip"></i> Cras mattis consectetur purus sit amet fermentum.</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span></span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#"><i class="fa fa-paperclip"></i> New developments in Bitcoin Cash</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span></span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#"><i class="fa fa-paperclip"></i> New developments in Bitcoin Cash</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span></span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#"><i class="fa fa-paperclip"></i> New developments in Bitcoin Cash</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span></span>
+                                        </div>
+                                    </li>
+
+                                    <li>
+                                        <a href="#"><i class="fa fa-paperclip"></i> New developments in Bitcoin Cash</a>
+                                        <div class="meta">
+                                            <span class="date">October 21, 2017</span></span>
+                                        </div>
+                                    </li>
+
+                                    
+                                </ul>
+                            </div>
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
As per discussion in slack #general with @peso (afrikoin@gmail.com) - he was saying that media has a tougher time writing about Bitcoin Cash due to quotes going direct to websites such as bitsonline or bitcoin.com - which they can't use. He recommended any quotes from Development team to articles be included in a press release to allow more writers to re-use the same quotes without getting in trouble.

We discussed adding a Press Release section. @peso also offered to write Press Releases for Bitcoin Cash, he just needs a full days notice. But if we have any public updates from development team it might be good to place press releases online as well as highlight stories on Bitcoin Cash. 

This section isn't perfect as it will struggle with > 15-20 Press Releases or Articles, but it buys time. 

If someone can find 5-10 articles to link to for "In the news" and if we can dig up or write 3 press releases re: bitcoin cash it should be safe to go up.

![image](https://i.gyazo.com/7120b8e729ceaf5bfb5d2526460b706b.gif)

