### PR TITLE
Added Freewallet

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -361,6 +361,9 @@ gtag('config', 'UA-17656782-2');
                         <div class="col-sm-6 col-md-3 vertical-align to-animate">
                             <a href="https://walletgenerator.net/?currency=BitcoinCash" target="_blank"><img alt="WalletGenerator.net" src="/img/wallets/walletgenerator.png"></a>
                         </div>
+                        <div class="col-sm-6 col-md-3 vertical-align to-animate">
+                            <a href="http://freewallet.org/currency/bch" target="_blank"><img alt="Freewallet.org" src="https://lh3.googleusercontent.com/yP0M_iqX-IY9zO0MBmzHxR0wqSw3g0kEExQtQkhp1Rn1UkuCuYus7s2WrmqDAVsgmuass7k7oECE-4o=w1440-h839"></a>
+                        </div>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
Freewallet was the first wallet to support Bitcoin Cash. Now Freewallet has dedicated wallet on iOS, Android and also Bitcoin Cash is listed in Freewallet Multiwallet (iOS, Android, web version)