### PR TITLE
Update broken link

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -512,7 +512,7 @@
             <a href="https://evercoin.com/" target="_blank"><img alt="Evercoin" src="/img/exchanges/evercoin.png"></a>
           </div>
           <div class="col-sm-4 col-md-3 vertical-align to-animate">
-            <a href="https://bitcoin.vn" target="_blank"><img alt="Bitcoin Vietnam" src="/img/exchanges/bitcoinvietnam.png"></a>
+            <a href="https://bitcoinvn.io" target="_blank"><img alt="BitcoinVN" src="/img/exchanges/bitcoinvietnam.png"></a>
           </div>
           <div class="col-sm-4 col-md-3 vertical-align to-animate">
             <a href="https://coinone.co.kr/" target="_blank"><img alt="Coinone" src="/img/exchanges/coinone.png"></a>


### PR DESCRIPTION
Just updating the new link for the exchange BitcoinVN (formerly known as Bitcoin Vietnam). Logo will be updated later.