### PR TITLE
Fix non standard property zoom

### DIFF
--- a/html/css/custom.css
+++ b/html/css/custom.css
@@ -1086,7 +1086,7 @@ h6 {
   margin-bottom: 30px;
   display: -moz-inline-stack;
   display: inline-block;
-  zoom: 1;
+  zoom: scale(1);
   *display: inline;
 }
 #fh5co-services .icon:before {
@@ -1610,7 +1610,7 @@ h6 {
   position: relative;
   display: -moz-inline-stack;
   display: inline-block;
-  zoom: 1;
+  zoom: scale(1);
   *display: inline;
   width: 25px;
   height: 3px;


### PR DESCRIPTION
You should not use: `zoom: 1;` in your CSS. I use this in together with `calc()`.
However, other external sources (like bootstrap) will be not changed. We better upgrade those external dependencies as well in a separate PR.

![image](https://user-images.githubusercontent.com/628926/200092356-f95fc6ea-f910-45e8-93a9-96f69d95e40f.png)
