### PR TITLE
Coinbase wallet removes BCH support

### DIFF
--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -264,9 +264,6 @@
             <a href="https://brd.com/" target="_blank"><img loading="lazy" alt="BRD" src="/img/wallets/bread.webp"></a>
           </div>
           <div class="col-sm-6 col-md-3 vertical-align">
-            <a href="https://wallet.coinbase.com/" target="_blank"><img loading="lazy" alt="Coinbase Wallet" src="/img/wallets/coinbase-wallet.webp"></a>
-          </div>
-          <div class="col-sm-6 col-md-3 vertical-align">
             <a href="https://zapit.io/" target="_blank"><img loading="lazy" alt="Zapit" src="/img/wallets/zapit.webp"></a>
           </div>
           <div class="col-sm-6 col-md-3 vertical-align">


### PR DESCRIPTION
Read also: https://techstory.in/crypto-wallet-coinbase-stoping-bch-etc-xlm-and-xrp-support-citing-low-usage/