### PR TITLE
Disable smartBCH

### DIFF
--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -659,12 +659,12 @@
     </div>
   </section>
   <%- if I18n.exists?(:'sections.smartbch') -%>
-    <a id="smartbch"></a>
+    <!-- <a id="smartbch"></a>
     <section class="space--xxs text-center gray border-bottom" id="smartbch-section"  data-section="smartbch">
       <div class="container exchanges">
         <div class="row">
           <div class="col-xs-12 section-heading ">
-            <h2><%= I18n.t(:'headings.smartbch').strip %></h2>
+            <h2>< %= I18n.t(:'headings.smartbch').strip %></h2>
           </div>
         </div>
         <div class="row">
@@ -736,6 +736,7 @@
           </div>
         </div>
       </section>
+    -->
     <%- end -%>
     <a id="exchanges"></a>
     <section class="space--xxs text-center gray" id="exchanges-section"  data-section="exchanges">


### PR DESCRIPTION
SmartBCH is imploded and is broken for now. Well, you most likely also know what happened there..

They don't update [their website](https://smartbch.org/), so instead of removing the content let's comment it out.

Even if the new bridge comes up, there is still a x million gap of hijacked funds. 

Anyway, maybe it's better to also update the site with CashToken info.