### PR TITLE
Add back the hub (flowee)

### DIFF
--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -416,6 +416,9 @@
         <div class="col-sm-6 col-md-6 vertical-align">
           <a href="https://kth.cash" target="_blank" rel="noopener"><img loading="lazy" alt="Knuth" src="/img/wallets/knuth.webp"></a>
         </div>
+        <div class="col-sm-6 col-md-6 vertical-align">
+          <a href="https://flowee.org" target="_blank" rel="noopener"><img loading="lazy" alt="Flowee The Hub" src="/img/wallets/flowee.webp"></a>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
For some reason the hub was removed for quite some time. 😖 

<img width="2448" height="1092" alt="image" src="https://github.com/user-attachments/assets/332e2c28-4417-4393-8c00-05e1814c68db" />
